### PR TITLE
Enables GraalVM native image build & run

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,14 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        // for Bytecode Enhancement
+        // http://docs.jboss.org/hibernate/orm/5.4/topical/html_single/bytecode/BytecodeEnhancement.html
+        classpath "org.hibernate:hibernate-gradle-plugin:5.4.0.Final"
+    }
+}
+
 plugins {
     id "io.spring.dependency-management" version "1.0.6.RELEASE"
     id "com.github.johnrengelman.shadow" version "4.0.2"
@@ -6,6 +17,9 @@ plugins {
     id "net.ltgt.apt-eclipse" version "0.21"
     id "net.ltgt.apt-idea" version "0.21"
 }
+
+// for Bytecode Enhancement
+apply plugin: 'org.hibernate.orm'
 
 version "0.1"
 group "example.micronaut"
@@ -68,4 +82,14 @@ test {
 tasks.withType(JavaCompile){
     options.encoding = "UTF-8"
     options.compilerArgs.add('-parameters')
+}
+
+// for Bytecode Enhancement
+hibernate {
+    enhance {
+        enableLazyInitialization= true
+        enableDirtyTracking = true
+        enableAssociationManagement = true
+        enableExtendedEnhancement = false
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -43,11 +43,13 @@ dependencies {
     compile "io.micronaut:micronaut-runtime"
     compileOnly "com.oracle.substratevm:svm"
     runtime "ch.qos.logback:logback-classic:1.2.3"
-    runtime 'mysql:mysql-connector-java:8.0.13'
     testAnnotationProcessor "io.micronaut:micronaut-inject-java"
     testCompile "org.junit.jupiter:junit-jupiter-api"
     testCompile "io.micronaut.test:micronaut-test-junit5"
     testRuntime "org.junit.jupiter:junit-jupiter-engine"
+
+    compile 'xerces:xercesImpl:2.12.0'
+    runtime 'org.postgresql:postgresql:42.2.4'
 }
 
 shadowJar {

--- a/dynamic-proxy/config.json
+++ b/dynamic-proxy/config.json
@@ -1,0 +1,4 @@
+[
+  ["java.sql.Statement"],
+  ["java.sql.PreparedStatement"]
+]

--- a/src/main/java/example/micronaut/Application.java
+++ b/src/main/java/example/micronaut/Application.java
@@ -1,7 +1,24 @@
 package example.micronaut;
 
+import io.micronaut.core.annotation.TypeHint;
 import io.micronaut.runtime.Micronaut;
+import org.hibernate.boot.model.naming.ImplicitNamingStrategyJpaCompliantImpl;
+import org.hibernate.dialect.PostgreSQL95Dialect;
+import org.hibernate.id.IdentityGenerator;
+import org.hibernate.persister.entity.SingleTableEntityPersister;
+import org.hibernate.tuple.entity.EntityMetamodel;
+import org.hibernate.tuple.entity.PojoEntityTuplizer;
+import org.springframework.orm.hibernate5.SpringSessionContext;
 
+@TypeHint({
+    ImplicitNamingStrategyJpaCompliantImpl.class,
+    PostgreSQL95Dialect.class,
+    IdentityGenerator.class,
+    SingleTableEntityPersister.class,
+    EntityMetamodel.class,
+    PojoEntityTuplizer.class,
+    SpringSessionContext.class
+})
 public class Application {
 
     public static void main(String[] args) {

--- a/src/main/java/example/micronaut/NoScanMetadataSourcesFactoryBean.java
+++ b/src/main/java/example/micronaut/NoScanMetadataSourcesFactoryBean.java
@@ -1,0 +1,26 @@
+package example.micronaut;
+
+import io.micronaut.configuration.hibernate.jpa.EntityManagerFactoryBean;
+import io.micronaut.configuration.hibernate.jpa.JpaConfiguration;
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Replaces;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+
+@Factory
+public class NoScanMetadataSourcesFactoryBean {
+
+    @EachBean(StandardServiceRegistry.class)
+    @Replaces(value = MetadataSources.class, factory = EntityManagerFactoryBean.class)
+    protected MetadataSources hibernateMetadataSources(
+        @Parameter JpaConfiguration jpaConfiguration,
+        StandardServiceRegistry standardServiceRegistry) {
+
+        // It seems we can't scan @Entity with native-image
+        MetadataSources metadataSources = new MetadataSources(standardServiceRegistry);
+        metadataSources.addAnnotatedClass(User.class);
+        return metadataSources;
+    }
+}

--- a/src/main/java/example/micronaut/NoScanMetadataSourcesFactoryBean.java
+++ b/src/main/java/example/micronaut/NoScanMetadataSourcesFactoryBean.java
@@ -6,11 +6,24 @@ import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.beans.BeanIntrospection;
+import io.micronaut.core.beans.BeanIntrospector;
+import io.micronaut.core.util.ArrayUtils;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 
+import javax.annotation.Nonnull;
+import javax.persistence.Entity;
+
 @Factory
 public class NoScanMetadataSourcesFactoryBean {
+
+    private Environment environment;
+
+    public NoScanMetadataSourcesFactoryBean(Environment environment) {
+        this.environment = environment;
+    }
 
     @EachBean(StandardServiceRegistry.class)
     @Replaces(value = MetadataSources.class, factory = EntityManagerFactoryBean.class)
@@ -18,9 +31,26 @@ public class NoScanMetadataSourcesFactoryBean {
         @Parameter JpaConfiguration jpaConfiguration,
         StandardServiceRegistry standardServiceRegistry) {
 
-        // It seems we can't scan @Entity with native-image
-        MetadataSources metadataSources = new MetadataSources(standardServiceRegistry);
-        metadataSources.addAnnotatedClass(User.class);
+        // Environment scan doesn't work with native image.
+        MetadataSources metadataSources = createMetadataSources(standardServiceRegistry);
+        String[] packagesToScan = getPackagesToScan(jpaConfiguration);
+        BeanIntrospector.SHARED
+            .findIntrospections(Entity.class, packagesToScan).stream()
+            .map(BeanIntrospection::getBeanType)
+            .forEach(metadataSources::addAnnotatedClass);
         return metadataSources;
     }
+
+    private String[] getPackagesToScan(JpaConfiguration jpaConfiguration) {
+        String[] packagesToScan = jpaConfiguration.getPackagesToScan();
+        if(ArrayUtils.isNotEmpty(packagesToScan)) {
+            return packagesToScan;
+        }
+        return environment.getPackages().toArray(new String[0]);
+    }
+
+    private MetadataSources createMetadataSources(@Nonnull StandardServiceRegistry serviceRegistry) {
+        return new MetadataSources(serviceRegistry);
+    }
+
 }

--- a/src/main/java/example/micronaut/User.java
+++ b/src/main/java/example/micronaut/User.java
@@ -11,24 +11,24 @@ import javax.validation.constraints.Size;
 
 @Entity
 @Table(name = "users")
-public class User {
+public final class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    public Long id;
 
     @NotBlank
     @Column(nullable = false, unique = true)
     @Size(min = 1, max = 100)
-    private String username;
+    public String username;
 
     @NotBlank
     @Size(max = 50)
     @Column(name = "first_name", nullable = false, length = 50)
-    private String firstName;
+    public String firstName;
 
     @Size(max = 50)
     @Column(name = "last_name")
-    private String lastName;
+    public String lastName;
 
     public User() {
     }

--- a/src/main/java/example/micronaut/User.java
+++ b/src/main/java/example/micronaut/User.java
@@ -11,24 +11,24 @@ import javax.validation.constraints.Size;
 
 @Entity
 @Table(name = "users")
-public final class User {
+public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public Long id;
+    private Long id;
 
     @NotBlank
     @Column(nullable = false, unique = true)
     @Size(min = 1, max = 100)
-    public String username;
+    private String username;
 
     @NotBlank
     @Size(max = 50)
     @Column(name = "first_name", nullable = false, length = 50)
-    public String firstName;
+    private String firstName;
 
     @Size(max = 50)
     @Column(name = "last_name")
-    public String lastName;
+    private String lastName;
 
     public User() {
     }

--- a/src/main/resources/META-INF/native-image/example.micronaut/hibernate-application/native-image.properties
+++ b/src/main/resources/META-INF/native-image/example.micronaut/hibernate-application/native-image.properties
@@ -1,3 +1,5 @@
 Args = -H:IncludeResources=logback.xml|application.yml \
        -H:Name=hibernate-graal \
-       -H:Class=example.micronaut.Application
+       -H:Class=example.micronaut.Application \
+       -H:DynamicProxyConfigurationFiles=dynamic-proxy/config.json \
+       --delay-class-initialization-to-runtime=org.apache.commons.logging.LogAdapter$Log4jLog,org.hibernate.secure.internal.StandardJaccServiceImpl,org.postgresql.sspi.SSPIClient,org.hibernate.dialect.OracleTypesHelper

--- a/src/main/resources/META-INF/native-image/example.micronaut/hibernate-application/native-image.properties
+++ b/src/main/resources/META-INF/native-image/example.micronaut/hibernate-application/native-image.properties
@@ -2,4 +2,5 @@ Args = -H:IncludeResources=logback.xml|application.yml \
        -H:Name=hibernate-graal \
        -H:Class=example.micronaut.Application \
        -H:DynamicProxyConfigurationFiles=dynamic-proxy/config.json \
+       -H:ReflectionConfigurationResources=${.}/reflection-config.json \
        --delay-class-initialization-to-runtime=org.apache.commons.logging.LogAdapter$Log4jLog,org.hibernate.secure.internal.StandardJaccServiceImpl,org.postgresql.sspi.SSPIClient,org.hibernate.dialect.OracleTypesHelper

--- a/src/main/resources/META-INF/native-image/example.micronaut/hibernate-application/reflection-config.json
+++ b/src/main/resources/META-INF/native-image/example.micronaut/hibernate-application/reflection-config.json
@@ -1,0 +1,6 @@
+[ {
+  "name" : "example.micronaut.User",
+  "allPublicMethods" : true,
+  "allDeclaredFields" : true,
+  "allDeclaredConstructors" : true
+} ]

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,10 +6,10 @@ micronaut:
 ---
 datasources:
   default:
-    url: 'jdbc:mysql://localhost:3306/mydb'
+    url: 'jdbc:postgresql://localhost:5432/mydb'
     username: root
     password: secret
-    driverClassName: com.mysql.cj.jdbc.Driver
+    driverClassName: org.postgresql.Driver
 jpa:
   default:
     packages-to-scan:
@@ -18,3 +18,4 @@ jpa:
       hibernate:
         hbm2ddl:
           auto: update
+        dialect: org.hibernate.dialect.PostgreSQL95Dialect


### PR DESCRIPTION
This modification enables GraalVM native image build of the project.
Reference: https://github.com/micronaut-projects/micronaut-core/issues/1569

* Changed to use BeanIntrospector for MetadataSources generation, because environment.scan doesn't work well with native image (this is the main cause of null entity manager)
* Added TypeHint configurations
* Added Dynamic Proxy configurations
* Configured build-time enhancement of Hibernate, because runtime proxy doesn't work with native image
* Set `allDeclaredFields` for User class, because it's required to get annotation on runtime but `@Introspected`, which is generated by `EntityIntrospectedAnnotationMapper`, only support `allPublicFields`.
* Switch to use PostgreSQL instead of MySQL, because MySQL JDBC driver doesn't work with native image currently

Here's a command I used to start PostgreSQL:
```sh
docker run -it --rm -p 5432:5432 -e POSTGRES_USER=root \
  -e POSTGRES_PASSWORD=secret -e POSTGRES_DB=mydb postgres:11.2-alpine
```

